### PR TITLE
File modal component

### DIFF
--- a/packages/mapo-webapp/src/app/components/new-file-modal/new-file-modal.component.html
+++ b/packages/mapo-webapp/src/app/components/new-file-modal/new-file-modal.component.html
@@ -1,0 +1,13 @@
+<div class="modal-bg-overlay" (click)="onClickBackground($event)"></div>
+
+<div class="modal">
+    <h3>New File</h3>
+
+    <label for="input">Name</label>
+    <input type="text" id="input" placeholder="File Name" [(ngModel)]="name"/>
+
+    <div class="button-row">
+        <button (click)="onClickCancel()">Cancel</button>
+        <button (click)="onClickCreateFile()">Create File</button>
+    </div>
+</div>

--- a/packages/mapo-webapp/src/app/components/new-file-modal/new-file-modal.component.less
+++ b/packages/mapo-webapp/src/app/components/new-file-modal/new-file-modal.component.less
@@ -1,0 +1,54 @@
+@import '../../../mixins.less';
+
+.modal-bg-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+
+.modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    height: fit-content;
+    width: fit-content;
+
+    background-color: white;
+    border: solid 2px black;
+    border-radius: 16px;
+    padding: 1rem;
+
+    z-index: 100;
+}
+
+h3 {
+    margin: 0;
+    margin-bottom: 3rem;
+    font-size: 24px;
+    font-weight: 500;
+    display: block;
+}
+
+input {
+    margin-left: 1rem;
+
+    .text-input();
+    min-width: 50ch;
+}
+
+.button-row {
+    margin-top: 5rem;
+    display: block;
+    text-align: right;
+
+    button {
+        margin-left: 1rem;
+        .text-button();
+    }
+}
+
+

--- a/packages/mapo-webapp/src/app/components/new-file-modal/new-file-modal.component.ts
+++ b/packages/mapo-webapp/src/app/components/new-file-modal/new-file-modal.component.ts
@@ -1,0 +1,38 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+export interface NewFileModalSubmit {
+  name: string;
+}
+
+@Component({
+  selector: 'app-new-file-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './new-file-modal.component.html',
+  styleUrl: './new-file-modal.component.less'
+})
+export class NewFileModalComponent {
+
+  name: string = '';
+
+  @Output() close = new EventEmitter();
+  @Output() submit = new EventEmitter<NewFileModalSubmit>();
+
+  onClickBackground(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      this.close.emit();
+    }
+  }
+
+  onClickCancel() {
+    this.close.emit();
+  }
+
+  onClickCreateFile() {
+    this.submit.emit({ 
+      name: this.name 
+    });
+  }
+}

--- a/packages/mapo-webapp/src/app/pages/files-page/files-page.component.html
+++ b/packages/mapo-webapp/src/app/pages/files-page/files-page.component.html
@@ -63,4 +63,11 @@
     (close)="onCloseNewFolderModal()"
     (submit)="onSubmitNewFolderModal($event)"
   ></app-new-folder-modal>
+
+  <app-new-file-modal 
+  *ngIf="isNewFileModalVisible"
+  (close)="onCloseNewFileModal()"
+  (submit)="onSubmitNewFileModal($event)"
+  ></app-new-file-modal>
+
 </div>

--- a/packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts
+++ b/packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts
@@ -14,6 +14,7 @@ import { BehaviorSubject, combineLatest, map } from 'rxjs';
 import { NewFolderModalComponent, NewFolderModalSubmit } from '../../components/new-folder-modal/new-folder-modal.component';
 import { Folder } from '../../models/folder.interface';
 import { FilesSelectors } from '../../selectors/file.selectors';
+import { NewFileModalComponent, NewFileModalSubmit } from '../../components/new-file-modal/new-file-modal.component';
 
 @Component({
   selector: 'app-files-page',
@@ -37,6 +38,9 @@ export class FilesPageComponent {
     this.filesService.fetch();
   }
 
+  //is this all i need to do? 
+  //or do i need to create functions similar to the ones below?
+  isNewFileModalVisible = true;
   isNewFolderModalVisible = false;
 
   searchText = new BehaviorSubject<string>('');

--- a/packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts
+++ b/packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts
@@ -98,17 +98,14 @@ export class FilesPageComponent {
     this.isNewFolderModalVisible = true;
   }
 
-  onClickNewFile() {
-    this.isNewFileModalVisible = true;
-  }
-
   onClickNewMindMap() {
-    this.edgeStore.set([]);
-    this.textNodeStore.set([]);
-    this.titleStore.set('Untitled');
-    this.filesStore.setCurrentFileId(null);
+    this.isNewFileModalVisible = true;
+    // this.edgeStore.set([]);
+    // this.textNodeStore.set([]);
+    // this.titleStore.set('Untitled');
+    // this.filesStore.setCurrentFileId(null);
 
-    this.router.navigate(['canvas']);
+    // this.router.navigate(['canvas']);
   }
 
   onClickDeleteFile(file: File) {

--- a/packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts
+++ b/packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts
@@ -19,7 +19,7 @@ import { NewFileModalComponent, NewFileModalSubmit } from '../../components/new-
 @Component({
   selector: 'app-files-page',
   standalone: true,
-  imports: [CommonModule, NewFolderModalComponent],
+  imports: [CommonModule, NewFolderModalComponent, NewFileModalComponent],
   templateUrl: './files-page.component.html',
   styleUrl: './files-page.component.less',
 })
@@ -38,9 +38,7 @@ export class FilesPageComponent {
     this.filesService.fetch();
   }
 
-  //is this all i need to do? 
-  //or do i need to create functions similar to the ones below?
-  isNewFileModalVisible = true;
+  isNewFileModalVisible = false;
   isNewFolderModalVisible = false;
 
   searchText = new BehaviorSubject<string>('');
@@ -100,6 +98,10 @@ export class FilesPageComponent {
     this.isNewFolderModalVisible = true;
   }
 
+  onClickNewFile() {
+    this.isNewFileModalVisible = true;
+  }
+
   onClickNewMindMap() {
     this.edgeStore.set([]);
     this.textNodeStore.set([]);
@@ -138,6 +140,11 @@ export class FilesPageComponent {
   onCloseNewFolderModal() {
     this.isNewFolderModalVisible = false;
   }
+
+  onCloseNewFileModal() {
+    this.isNewFileModalVisible = false;
+  }
+
   onSubmitNewFolderModal(data: NewFolderModalSubmit) {
     this.filesService.createFolder(data.name, this.filesStore.currentFolderId.getValue())
       .then(() => {
@@ -152,8 +159,18 @@ export class FilesPageComponent {
       });
   }
 
+  onSubmitNewFileModal(data: NewFileModalSubmit) {
+    //not really sure what to do here.
+    //do i need to create a createFile service?
+    this.isNewFileModalVisible = false;
+  }
+
   onClickFolder(folder: Folder) {
     this.filesStore.setCurrentFolderId(folder.id);
+  }
+
+  onClickFile(file: File) {
+    this.filesStore.setCurrentFileId(file.id);
   }
 
   onClickDeleteFolder(folder: Folder, e: MouseEvent) {


### PR DESCRIPTION
Did I need to add functions like onClickFile and onSubmitNewFileModal in "[packages/mapo-webapp/src/app/pages/files-page/files-page.component.ts]?"

I am a little confused on how to implement onSubmitNewFileModal because there is no createFile service. Do I need to also create the service? I am also a little confused on why we need to create a Modal for Files. 

I felt comfortable creating the New File Modal Component:
HTML: Modal structure for inputting a file name.
CSS: Styles
TypeScript: The component handles input data and emits events for closing and submitting the modal.

I am a bit confused on the File Page Component:
I get that we are trying to integrate the new file modal component into the files page.
Adding methods to control the modal's visibility and to handle submission.