### PR TITLE
Added early-stopping condition to arrow rendering, prevents freezes

### DIFF
--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -218,12 +218,16 @@ export class FabricUtils {
     //
     // See: https://github.com/bensivo/mapo/issues/49
     if (src.intersectsWithObject(dest, true, true)) {
+      console.log('Arrow', id, 'between 2 intersecting nodes. Skipping render');
       return null;
     }
 
     // Iteratively push the start-point of the arrow towards the end, until it is no longer inside the src node
     // Then do 1 more push just for aesthetics
-    while (src.containsPoint(new fabric.Point(srcX, srcY), null, true)) {
+    while (
+      src.containsPoint(new fabric.Point(srcX, srcY), null, true) 
+      && FabricUtils.dist(srcX, srcY, destX, destY) > 10 // Prevents infinite loop if the arrow start and endpoints are very close
+    ) {
       const point = this.translateTowards(srcX, srcY, destX, destY, 5);
       srcX = point.x;
       srcY = point.y;
@@ -234,7 +238,10 @@ export class FabricUtils {
 
     // Iteratively push the end-point of the arrow towards the start, until it is no longer inside the dest node
     // Then do 1 more push just for aesthetics
-    while (dest.containsPoint(new fabric.Point(destX, destY), null, true)) {
+    while (
+      dest.containsPoint(new fabric.Point(destX, destY), null, true)
+      && FabricUtils.dist(srcX, srcY, destX, destY) > 10 // Prevents infinite loop if the arrow start and endpoints are very close
+    ) {
       const point = this.translateTowards(destX, destY, srcX, srcY, 5);
       destX = point.x;
       destY = point.y;
@@ -297,6 +304,14 @@ export class FabricUtils {
     canvas.add(poly);
     canvas.sendToBack(poly);
     return poly;
+  }
+
+  public static dist(srcX: number, srcY: number, destX: number, destY: number) {
+    const distX = (srcX - destX)*1.0;
+    const distY = (srcY - destY)*1.0;
+    const dist = Math.sqrt(Math.pow(distX, 2) + Math.pow(distY, 2));
+    console.log(dist);
+    return dist;
   }
 
   public static getCenterPoint(object: fabric.Object): fabric.Point {

--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -218,7 +218,6 @@ export class FabricUtils {
     //
     // See: https://github.com/bensivo/mapo/issues/49
     if (src.intersectsWithObject(dest, true, true)) {
-      console.log('Arrow', id, 'between 2 intersecting nodes. Skipping render');
       return null;
     }
 
@@ -310,7 +309,6 @@ export class FabricUtils {
     const distX = (srcX - destX)*1.0;
     const distY = (srcY - destY)*1.0;
     const dist = Math.sqrt(Math.pow(distX, 2) + Math.pow(distY, 2));
-    console.log(dist);
     return dist;
   }
 


### PR DESCRIPTION
The freeze issue was caused by an infinite loop in the src.containsPoint() and dest.containsPoint() while loops. 

These loops are what makes the arrow start and end points appear outside of the nodes, even though technically arrows start and end in the node centerpoints. 

However, when the nodes overlapped, the src.containsPoint() and dest.containsPoint() functiosn would just keep firing, no matter how much the arrows were 'nudged'. To prevent this, I just added a stopping condition to stop nudging if the arrow length was smaller than 10 (twice the nudge length). 