### PR TITLE
Feature: Comments

### DIFF
--- a/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
+++ b/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
@@ -26,8 +26,7 @@ export class TextNodeOptionsComponent {
     map(([tool, selection, isComment]) => {
       if (tool === Tool.EDIT_TEXT_NODE) {
         return false
-      }
-      console.log('TEXT NODE OPTIONS STORE, isComment =', isComment);
+      };
       if (isComment) {
         return false;
       }

--- a/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
+++ b/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
@@ -27,7 +27,7 @@ export class TextNodeOptionsComponent {
       if (tool === Tool.EDIT_TEXT_NODE) {
         return false
       }
-      console.log('TEXT NODE OPTIONS STORE', isComment);
+      console.log('TEXT NODE OPTIONS STORE, isComment =', isComment);
       if (isComment) {
         return false;
       }

--- a/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
+++ b/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
@@ -20,11 +20,16 @@ export class TextNodeOptionsComponent {
 
   isVisible$ = combineLatest([
     this.toolbarStore.tool$,
-    this.selectionService.selection$
+    this.selectionService.selection$,
+    this.textNodeOptionsStore.isComment$
   ]).pipe(
-    map(([tool, selection]) => {
+    map(([tool, selection, isComment]) => {
       if (tool === Tool.EDIT_TEXT_NODE) {
         return false
+      }
+      console.log('TEXT NODE OPTIONS STORE', isComment);
+      if (isComment) {
+        return false;
       }
 
       if (selection && selection.length !== 0) {

--- a/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
+++ b/packages/mapo-webapp/src/app/components/textnode-options/textnode-options.component.ts
@@ -21,17 +21,19 @@ export class TextNodeOptionsComponent {
   isVisible$ = combineLatest([
     this.toolbarStore.tool$,
     this.selectionService.selection$,
-    this.textNodeOptionsStore.isComment$
   ]).pipe(
-    map(([tool, selection, isComment]) => {
+    map(([tool, selection]) => {
       if (tool === Tool.EDIT_TEXT_NODE) {
         return false
       };
-      if (isComment) {
-        return false;
-      }
 
-      if (selection && selection.length !== 0) {
+      // Return true (make the options visible) only if there is at least 1
+      // text node in the selection
+      const hasTextNode = selection?.some((object) => {
+        return object.data?.type === 'text-node' && object.data?.isComment == false;
+      })
+
+      if (hasTextNode) {
         return true;
       }
 

--- a/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.html
+++ b/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.html
@@ -17,11 +17,10 @@
     <i class="ri-text-snippet"></i>
     <span class="subtext">t</span>
   </div>
-  <!-- create comment button -->
-  <div 
-  class="tool create-comment"
-  [ngClass]="{ enabled: tool === 'create-comment-node' }"
-  (click)="selectTool('create-comment-node')"
+  <div
+    class="tool create-comment"
+    [ngClass]="{ enabled: tool === 'create-comment-node' }"
+    (click)="selectTool('create-comment-node')"
   >
     <i class="ri-chat-4-line"></i>
     <span class="subtext">c</span>

--- a/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.html
+++ b/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.html
@@ -17,7 +17,12 @@
     <i class="ri-text-snippet"></i>
     <span class="subtext">t</span>
   </div>
-  <div class="tool create-comment">
+  <!-- create comment button -->
+  <div 
+  class="tool create-comment"
+  [ngClass]="{ enabled: tool === 'create-comment-node' }"
+  (click)="selectTool('create-comment-node')"
+  >
     <i class="ri-chat-4-line"></i>
     <span class="subtext">c</span>
   </div>

--- a/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.html
+++ b/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.html
@@ -17,6 +17,10 @@
     <i class="ri-text-snippet"></i>
     <span class="subtext">t</span>
   </div>
+  <div class="tool create-comment">
+    <i class="ri-chat-4-line"></i>
+    <span class="subtext">c</span>
+  </div>
   <div
     data-testid="toolbar-edge"
     class="tool create-edge"

--- a/packages/mapo-webapp/src/app/models/textnode.model.ts
+++ b/packages/mapo-webapp/src/app/models/textnode.model.ts
@@ -5,7 +5,8 @@ export const TextNodeSchema = z.object({
   text: z.string(),
   x: z.number(),
   y: z.number(),
-  color: z.string().optional()
+  color: z.string().optional(),
+  isComment: z.boolean().default(false)
 });
 
 export type TextNode = z.infer<typeof TextNodeSchema>;

--- a/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
+++ b/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
@@ -13,20 +13,11 @@ export class DebugController {
   constructor(
     private canvasService: CanvasService,
     private textNodeService: TextNodeService,
-    //add textNodeStore
     private textNodeStore: TextNodeStore,
   ) {
 
     this.canvasService.canvasInitialized$.subscribe((canvas) => {
       this.canvas = canvas;
-      //insert a text node
-      this.textNodeStore.insert({
-        id: "adsf",
-        text: "saljdfhdf",
-        x: 0,
-        y: 0,
-        isComment: false,
-      });
     });
 
     // Add functions to the window object, so they can be executed by an e2e test suite

--- a/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
+++ b/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import { TextNodeService } from "../text-node/text-node.service";
+import { TextNodeStore } from "../../store/text-node.store";
 import { CanvasService } from "../canvas/canvas.service";
 
 @Injectable({
@@ -12,10 +13,19 @@ export class DebugController {
   constructor(
     private canvasService: CanvasService,
     private textNodeService: TextNodeService,
+    //add textNodeStore
+    private textNodeStore: TextNodeStore,
   ) {
 
     this.canvasService.canvasInitialized$.subscribe((canvas) => {
       this.canvas = canvas;
+      //insert a text node
+      this.textNodeStore.insert({
+        id: "adsf",
+        text: "saljdfhdf",
+        x: 0,
+        y: 0,
+      });
     });
 
     // Add functions to the window object, so they can be executed by an e2e test suite

--- a/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
+++ b/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
@@ -42,7 +42,7 @@ export class DebugController {
 
   addTextNode = (text: string, x: number, y: number) => {
     console.log('Adding text node', text, x, y);
-    const pending = this.textNodeService.addPendingTextNode(x, y);
+    const pending = this.textNodeService.addPendingTextNode(x, y, false); //maybe change later?
     pending.text = text;
     this.textNodeService.finalizeTextNode(pending);
   }

--- a/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
+++ b/packages/mapo-webapp/src/app/services/debug/debug.controller.ts
@@ -25,6 +25,7 @@ export class DebugController {
         text: "saljdfhdf",
         x: 0,
         y: 0,
+        isComment: false,
       });
     });
 

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
@@ -85,7 +85,12 @@ export class TextNodeController {
       return;
     }
 
-    if (this.toolbarStore.tool.value === Tool.CREATE_TEXT_NODE) {
+    if (
+      this.toolbarStore.tool.value === Tool.CREATE_TEXT_NODE ||
+      this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE //right now lets just make comment do the same thing
+    ) {
+      console.log('CREATE TEXT NODE COMMENT NODE');
+
       if (!e.absolutePointer) {
         console.warn('No absolute pointer on event', e);
         return;

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
@@ -64,7 +64,7 @@ export class TextNodeController {
       const itext = this.textNodeService.addPendingTextNode(
         e.absolutePointer.y,
         e.absolutePointer.x,
-        isComment
+        isComment,
       );
       itext.on('editing:exited', () => {
         this.onITextExited(itext);
@@ -88,14 +88,10 @@ export class TextNodeController {
       return;
     }
 
-    //this determines if isComment is true or false
+    //this determines if isComment = true or false
     const isComment = this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE;
 
-    if (
-      this.toolbarStore.tool.value === Tool.CREATE_TEXT_NODE ||
-      isComment //right now lets just make comment do the same thing
-    ) {
-
+    if (this.toolbarStore.tool.value === Tool.CREATE_TEXT_NODE || isComment) {
       if (!e.absolutePointer) {
         console.warn('No absolute pointer on event', e);
         return;
@@ -104,7 +100,7 @@ export class TextNodeController {
       const itext = this.textNodeService.addPendingTextNode(
         e.absolutePointer.y,
         e.absolutePointer.x,
-        isComment
+        isComment,
       );
       this.canvas.requestRenderAll();
       itext.on('editing:exited', () => {

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
@@ -88,6 +88,7 @@ export class TextNodeController {
       return;
     }
 
+    //this determines if isComment is true or false
     const isComment = this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE;
 
     if (

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
@@ -89,7 +89,6 @@ export class TextNodeController {
       this.toolbarStore.tool.value === Tool.CREATE_TEXT_NODE ||
       this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE //right now lets just make comment do the same thing
     ) {
-      console.log('CREATE TEXT NODE COMMENT NODE');
 
       if (!e.absolutePointer) {
         console.warn('No absolute pointer on event', e);

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.controller.ts
@@ -56,12 +56,15 @@ export class TextNodeController {
       return;
     }
 
+    const isComment = this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE;
+
     if (!e.target && e.absolutePointer) {
       // double-click on empty space on the canvas
       // Add pending text node, itext
       const itext = this.textNodeService.addPendingTextNode(
         e.absolutePointer.y,
         e.absolutePointer.x,
+        isComment
       );
       itext.on('editing:exited', () => {
         this.onITextExited(itext);
@@ -85,9 +88,11 @@ export class TextNodeController {
       return;
     }
 
+    const isComment = this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE;
+
     if (
       this.toolbarStore.tool.value === Tool.CREATE_TEXT_NODE ||
-      this.toolbarStore.tool.value === Tool.CREATE_COMMENT_NODE //right now lets just make comment do the same thing
+      isComment //right now lets just make comment do the same thing
     ) {
 
       if (!e.absolutePointer) {
@@ -98,6 +103,7 @@ export class TextNodeController {
       const itext = this.textNodeService.addPendingTextNode(
         e.absolutePointer.y,
         e.absolutePointer.x,
+        isComment
       );
       this.canvas.requestRenderAll();
       itext.on('editing:exited', () => {

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.spec.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.spec.ts
@@ -71,12 +71,14 @@ describe('TextNodeService', () => {
         text: 'Hello',
         x: 0,
         y: 0,
+        isComment: false,
       };
       const textnode2: TextNode = {
         id: '2',
         text: 'Hello',
         x: 0,
         y: 0,
+        isComment: false,
       };
 
       // Given there is a canvas
@@ -94,7 +96,7 @@ describe('TextNodeService', () => {
   describe('addPendingTextNode', () => {
     it('should throw an error if there is no canvas', () => {
       expect(() => {
-        service.addPendingTextNode(0, 0);
+        service.addPendingTextNode(0, 0, false);
       }).toThrowError('No canvas on TextNodeService');
     });
 
@@ -108,7 +110,7 @@ describe('TextNodeService', () => {
       mockCanvasService.canvasInitialized$.next(canvas);
 
       // When we call addPendingTextNode
-      service.addPendingTextNode(0, 0);
+      service.addPendingTextNode(0, 0, false);
 
       // Then an itext is created
       expect(createITextSpy).toHaveBeenCalledWith(canvas, '', 0, 0);

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -147,7 +147,6 @@ export class TextNodeService {
       centerY,
       centerX,
     );
-
     FabricUtils.selectIText(this.canvas, itext);
     this.toolbarStore.setTool(Tool.EDIT_TEXT_NODE);
 

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -20,7 +20,6 @@ export class TextNodeService {
     private canvasService: CanvasService,
     private toolbarStore: ToolbarStore,
     private textNodeStore: TextNodeStore,
-    private textNodeOptionsStore: TextNodeOptionsStore, // TODO: ask Ben if its okay to have this service interact with the textnode-options 
   ) {
     this.canvasService.canvasInitialized$.subscribe((canvas) => {
       this.canvas = canvas;
@@ -59,8 +58,8 @@ export class TextNodeService {
 
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
 
-    if(isComment) {
-      this.textNodeOptionsStore.setIsComment(true); // TODO: ask Ben if its okay to have this service interact with the textnode-options
+    console.log('Pending Text Node, isComment:', isComment);
+    if (isComment) {
       itext.data = {
         isComment: true,
       };
@@ -88,7 +87,8 @@ export class TextNodeService {
     }
 
     const isComment = itext.data?.isComment || false;
-    
+    console.log('Finalized Text Node, isComment:', isComment);
+
     this.canvas.remove(itext);
     this.textNodeStore.insert({
       id: uuid.v4(),

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -80,7 +80,8 @@ export class TextNodeService {
       text: text,
       x: x,
       y: y,
-      color: '#FFFFFF'
+      color: '#FFFFFF',
+      isComment: false
     });
     this.toolbarStore.setTool(Tool.POINTER);
   }

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -79,7 +79,7 @@ export class TextNodeService {
       console.warn('Cannot create text node. Invalid data for itext: ', itext);
       return;
     }
-
+    
     this.canvas.remove(itext);
     this.textNodeStore.insert({
       id: uuid.v4(),
@@ -87,7 +87,7 @@ export class TextNodeService {
       x: x,
       y: y,
       color: '#FFFFFF',
-      isComment: false,
+      isComment: false, //im not sure what to put here
     });
     this.toolbarStore.setTool(Tool.POINTER);
   }

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -62,9 +62,9 @@ export class TextNodeService {
 
     //set different style for the comment
     if(isComment) {
-      itext.set({
-        fill: '#FF0000',
-      });
+      // itext.set({
+      //   fill: '#FF0000',
+      // });
       itext.data = {
         type: 'comment-node',
         isComment: true,
@@ -105,6 +105,7 @@ export class TextNodeService {
       color: '#FFFFFF',
       isComment: isComment,
     });
+
     this.toolbarStore.setTool(Tool.POINTER);
   }
 
@@ -155,6 +156,9 @@ export class TextNodeService {
       centerY,
       centerX,
     );
+
+    console.log('EDIT TEXT NODE'); //todo: delete later
+
     FabricUtils.selectIText(this.canvas, itext);
     this.toolbarStore.setTool(Tool.EDIT_TEXT_NODE);
 
@@ -196,6 +200,8 @@ export class TextNodeService {
       );
       return;
     }
+
+    console.log('UPDATE TEXT NODE'); //todo: delete later
 
     const x = group.left + 10; // Add 10 to account for the padding between the group and the itext itself
     const y = group.top + 10; // Add 10 to account for the padding between the group and the itext itself

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -58,7 +58,6 @@ export class TextNodeService {
 
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
 
-    console.log('Pending Text Node, isComment:', isComment);
     if (isComment) {
       itext.data = {
         isComment: true,
@@ -87,7 +86,6 @@ export class TextNodeService {
     }
 
     const isComment = itext.data?.isComment || false;
-    console.log('Finalized Text Node, isComment:', isComment);
 
     this.canvas.remove(itext);
     this.textNodeStore.insert({

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -42,11 +42,6 @@ export class TextNodeService {
     // Render all the text nodes
     for (const textNode of textNodes) {
       FabricUtils.createTextNode(this.canvas, textNode);
-
-      //if isComment = true
-      if (textNode.isComment) {
-        console.log('Rendering a comment node:', textNode);
-      }
     }
 
     this.canvas.requestRenderAll();
@@ -61,7 +56,7 @@ export class TextNodeService {
       throw new Error('No canvas on TextNodeService');
     }
 
-    console.log("Pending Text Node IsComment:", isComment);
+    console.log("Pending IsComment:", isComment);
 
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
 
@@ -99,7 +94,7 @@ export class TextNodeService {
 
     //check for comment 
     const isComment = itext.data?.isComment || false;
-    console.log('Finalized itext isComment', isComment);
+    console.log('Finalized isComment:', isComment);
     
     this.canvas.remove(itext);
     this.textNodeStore.insert({

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -20,7 +20,7 @@ export class TextNodeService {
     private canvasService: CanvasService,
     private toolbarStore: ToolbarStore,
     private textNodeStore: TextNodeStore,
-    private textNodeOptionsStore: TextNodeOptionsStore,
+    private textNodeOptionsStore: TextNodeOptionsStore, // TODO: ask Ben if its okay to have this service interact with the textnode-options 
   ) {
     this.canvasService.canvasInitialized$.subscribe((canvas) => {
       this.canvas = canvas;
@@ -57,19 +57,11 @@ export class TextNodeService {
       throw new Error('No canvas on TextNodeService');
     }
 
-    console.log("Pending IsComment:", isComment); //todo: del later
-    console.log('Pending Tool', this.toolbarStore);
-
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
 
-    //set different style for the comment
     if(isComment) {
-      this.textNodeOptionsStore.setIsComment(true); // maybe bad practice???
-      // itext.set({
-      //   fill: '#FF0000',
-      // });
+      this.textNodeOptionsStore.setIsComment(true); // TODO: ask Ben if its okay to have this service interact with the textnode-options
       itext.data = {
-        type: 'comment-node',
         isComment: true,
       };
     }
@@ -95,10 +87,7 @@ export class TextNodeService {
       return;
     }
 
-    //check for comment 
     const isComment = itext.data?.isComment || false;
-    console.log('Finalized isComment:', isComment); //todo: del later
-    console.log('Finalized Tool', this.toolbarStore);
     
     this.canvas.remove(itext);
     this.textNodeStore.insert({
@@ -161,9 +150,6 @@ export class TextNodeService {
       centerX,
     );
 
-    console.log('EDIT TEXT NODE'); //todo: delete later
-    console.log('Edit Text Node Tool', this.toolbarStore);
-
     FabricUtils.selectIText(this.canvas, itext);
     this.toolbarStore.setTool(Tool.EDIT_TEXT_NODE);
 
@@ -205,9 +191,6 @@ export class TextNodeService {
       );
       return;
     }
-
-    console.log('UPDATE TEXT NODE'); //todo: delete later
-    console.log('Update Text Node Tool', this.toolbarStore);
 
     const x = group.left + 10; // Add 10 to account for the padding between the group and the itext itself
     const y = group.top + 10; // Add 10 to account for the padding between the group and the itext itself

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -47,10 +47,16 @@ export class TextNodeService {
     this.canvas.requestRenderAll();
   }
 
-  addPendingTextNode(top: number, left: number): fabric.IText {
+  addPendingTextNode(
+    top: number,
+    left: number,
+    isComment: boolean,
+  ): fabric.IText {
     if (!this.canvas) {
       throw new Error('No canvas on TextNodeService');
     }
+
+    console.log("Pending Text Node IsComment:", isComment);
 
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
     FabricUtils.selectIText(this.canvas, itext);
@@ -81,7 +87,7 @@ export class TextNodeService {
       x: x,
       y: y,
       color: '#FFFFFF',
-      isComment: false
+      isComment: false,
     });
     this.toolbarStore.setTool(Tool.POINTER);
   }

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -20,6 +20,7 @@ export class TextNodeService {
     private canvasService: CanvasService,
     private toolbarStore: ToolbarStore,
     private textNodeStore: TextNodeStore,
+    private textNodeOptionsStore: TextNodeOptionsStore,
   ) {
     this.canvasService.canvasInitialized$.subscribe((canvas) => {
       this.canvas = canvas;
@@ -56,12 +57,14 @@ export class TextNodeService {
       throw new Error('No canvas on TextNodeService');
     }
 
-    console.log("Pending IsComment:", isComment);
+    console.log("Pending IsComment:", isComment); //todo: del later
+    console.log('Pending Tool', this.toolbarStore);
 
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
 
     //set different style for the comment
     if(isComment) {
+      this.textNodeOptionsStore.setIsComment(true); // maybe bad practice???
       // itext.set({
       //   fill: '#FF0000',
       // });
@@ -94,7 +97,8 @@ export class TextNodeService {
 
     //check for comment 
     const isComment = itext.data?.isComment || false;
-    console.log('Finalized isComment:', isComment);
+    console.log('Finalized isComment:', isComment); //todo: del later
+    console.log('Finalized Tool', this.toolbarStore);
     
     this.canvas.remove(itext);
     this.textNodeStore.insert({
@@ -158,6 +162,7 @@ export class TextNodeService {
     );
 
     console.log('EDIT TEXT NODE'); //todo: delete later
+    console.log('Edit Text Node Tool', this.toolbarStore);
 
     FabricUtils.selectIText(this.canvas, itext);
     this.toolbarStore.setTool(Tool.EDIT_TEXT_NODE);
@@ -202,6 +207,7 @@ export class TextNodeService {
     }
 
     console.log('UPDATE TEXT NODE'); //todo: delete later
+    console.log('Update Text Node Tool', this.toolbarStore);
 
     const x = group.left + 10; // Add 10 to account for the padding between the group and the itext itself
     const y = group.top + 10; // Add 10 to account for the padding between the group and the itext itself

--- a/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
+++ b/packages/mapo-webapp/src/app/services/text-node/text-node.service.ts
@@ -42,6 +42,11 @@ export class TextNodeService {
     // Render all the text nodes
     for (const textNode of textNodes) {
       FabricUtils.createTextNode(this.canvas, textNode);
+
+      //if isComment = true
+      if (textNode.isComment) {
+        console.log('Rendering a comment node:', textNode);
+      }
     }
 
     this.canvas.requestRenderAll();
@@ -59,6 +64,18 @@ export class TextNodeService {
     console.log("Pending Text Node IsComment:", isComment);
 
     const itext = FabricUtils.createIText(this.canvas, '', top, left);
+
+    //set different style for the comment
+    if(isComment) {
+      itext.set({
+        fill: '#FF0000',
+      });
+      itext.data = {
+        type: 'comment-node',
+        isComment: true,
+      };
+    }
+
     FabricUtils.selectIText(this.canvas, itext);
     this.toolbarStore.setTool(Tool.EDIT_TEXT_NODE);
 
@@ -79,6 +96,10 @@ export class TextNodeService {
       console.warn('Cannot create text node. Invalid data for itext: ', itext);
       return;
     }
+
+    //check for comment 
+    const isComment = itext.data?.isComment || false;
+    console.log('Finalized itext isComment', isComment);
     
     this.canvas.remove(itext);
     this.textNodeStore.insert({
@@ -87,7 +108,7 @@ export class TextNodeService {
       x: x,
       y: y,
       color: '#FFFFFF',
-      isComment: false, //im not sure what to put here
+      isComment: isComment,
     });
     this.toolbarStore.setTool(Tool.POINTER);
   }

--- a/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
+++ b/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
@@ -38,6 +38,13 @@ export class TextNodeOptionsController {
     });
   }
 
+  /**
+   * When a node (or group of nodes) is selected, set the selected color to the color
+   * of the node (or the color of the first node in the group).
+   * 
+   * @param objects 
+   * @returns 
+   */
   onSelection(objects: fabric.Object[] | null) {
     if (!objects) {
       return;
@@ -53,25 +60,6 @@ export class TextNodeOptionsController {
     if (colorsUnique.length === 1) {
         this.textNodeOptionsStore.setColor(colorsUnique[0] as string);
     }
-
-    const isComments = textNodes.map((textNode) => {
-      const nodeId = textNode?.data?.id;
-
-      if (!nodeId) {
-        console.log('No node id found');
-        return null;
-      }
-
-      const node = this.textNodeStore.get(nodeId);
-
-      if (!node) {
-        console.log('No node found in store');
-        return null;
-      }
-
-      this.textNodeOptionsStore.setIsComment(node.isComment);
-      return node.isComment;
-    });
   }
 
   /**

--- a/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
+++ b/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
@@ -1,9 +1,9 @@
-import { fabric } from 'fabric';
-import { Injectable } from '@angular/core';
-import { TextNodeOptionsStore } from '../../store/textnode-options.store';
-import { CanvasService } from '../canvas/canvas.service';
-import { TextNodeStore } from '../../store/text-node.store';
-import { SelectionService } from '../selection/selection.service';
+import { fabric } from "fabric";
+import { Injectable } from "@angular/core";
+import { TextNodeOptionsStore } from "../../store/textnode-options.store";
+import { CanvasService } from "../canvas/canvas.service";
+import { TextNodeStore } from "../../store/text-node.store";
+import { SelectionService } from "../selection/selection.service";
 
 @Injectable({
   providedIn: 'root',
@@ -41,19 +41,16 @@ export class TextNodeOptionsController {
     if (!objects) {
       return;
     }
-    const textNodes = objects.filter(
-      (object) =>
-        object instanceof fabric.Group && object?.data?.type === 'text-node',
-    );
+    const textNodes = objects.filter((object) => object instanceof fabric.Group && object?.data?.type === 'text-node',);
     const colors = textNodes.map((textNode) => {
       return (textNode as fabric.Group).item(0).fill;
-    });
+    })
 
     // Only set the color if all the selected objects are the same, otherwise,
     // setting a new color would switch all objects to that color.
     const colorsUnique = [...new Set(colors)];
     if (colorsUnique.length === 1) {
-      this.textNodeOptionsStore.setColor(colorsUnique[0] as string);
+        this.textNodeOptionsStore.setColor(colorsUnique[0] as string);
     }
 
     const isComments = textNodes.map((textNode) => {
@@ -91,10 +88,7 @@ export class TextNodeOptionsController {
 
     let updated = false;
     for (const object of objects) {
-      if (
-        object instanceof fabric.Group &&
-        object?.data?.type === 'text-node'
-      ) {
+      if (object instanceof fabric.Group && object?.data?.type === 'text-node') {
         const nodeId = object?.data?.id;
         if (!nodeId) {
           console.warn('No node id found', object);
@@ -115,7 +109,7 @@ export class TextNodeOptionsController {
     }
 
     if (updated) {
-      // Deselect all objects.
+      // Deselect all objects. 
       this.canvas.discardActiveObject().renderAll();
     }
   }

--- a/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
+++ b/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
@@ -1,15 +1,14 @@
-import { fabric } from "fabric";
-import { Injectable } from "@angular/core";
-import { TextNodeOptionsStore } from "../../store/textnode-options.store";
-import { CanvasService } from "../canvas/canvas.service";
-import { TextNodeStore } from "../../store/text-node.store";
-import { SelectionService } from "../selection/selection.service";
+import { fabric } from 'fabric';
+import { Injectable } from '@angular/core';
+import { TextNodeOptionsStore } from '../../store/textnode-options.store';
+import { CanvasService } from '../canvas/canvas.service';
+import { TextNodeStore } from '../../store/text-node.store';
+import { SelectionService } from '../selection/selection.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TextNodeOptionsController {
-
   canvas: fabric.Canvas | null = null;
 
   constructor(
@@ -42,40 +41,39 @@ export class TextNodeOptionsController {
     if (!objects) {
       return;
     }
-    const textNodes = objects.filter((object) => object instanceof fabric.Group && object?.data?.type === 'text-node');
+    const textNodes = objects.filter(
+      (object) =>
+        object instanceof fabric.Group && object?.data?.type === 'text-node',
+    );
     const colors = textNodes.map((textNode) => {
       return (textNode as fabric.Group).item(0).fill;
-    })
+    });
 
     // Only set the color if all the selected objects are the same, otherwise,
     // setting a new color would switch all objects to that color.
     const colorsUnique = [...new Set(colors)];
     if (colorsUnique.length === 1) {
-        this.textNodeOptionsStore.setColor(colorsUnique[0] as string);
+      this.textNodeOptionsStore.setColor(colorsUnique[0] as string);
     }
 
-    //TODO: need to somehow get the isComment state here.
-    //      then set the textnode-options.store to either true or false on selection
     const isComments = textNodes.map((textNode) => {
-        const nodeId = textNode?.data?.id;
+      const nodeId = textNode?.data?.id;
 
-        if (!nodeId) {
-          console.log('No node id found');
-          return null;
-        }
+      if (!nodeId) {
+        console.log('No node id found');
+        return null;
+      }
 
-        const node = this.textNodeStore.get(nodeId);
+      const node = this.textNodeStore.get(nodeId);
 
-        if (!node) {
-          console.log('No node found in store');
-          return null;
-        }
-        this.textNodeOptionsStore.setIsComment(node.isComment);
-        return node.isComment;
-    })
-    
-    console.log('ON SELECTION isComment: ', isComments);
+      if (!node) {
+        console.log('No node found in store');
+        return null;
+      }
 
+      this.textNodeOptionsStore.setIsComment(node.isComment);
+      return node.isComment;
+    });
   }
 
   /**
@@ -93,8 +91,10 @@ export class TextNodeOptionsController {
 
     let updated = false;
     for (const object of objects) {
-      if (object instanceof fabric.Group && object?.data?.type === 'text-node') {
-
+      if (
+        object instanceof fabric.Group &&
+        object?.data?.type === 'text-node'
+      ) {
         const nodeId = object?.data?.id;
         if (!nodeId) {
           console.warn('No node id found', object);
@@ -116,7 +116,7 @@ export class TextNodeOptionsController {
     }
 
     if (updated) {
-      // Deselect all objects. 
+      // Deselect all objects.
       this.canvas.discardActiveObject().renderAll();
     }
   }

--- a/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
+++ b/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
@@ -90,7 +90,7 @@ export class TextNodeOptionsController {
     let updated = false;
     for (const object of objects) {
       if (object instanceof fabric.Group && object?.data?.type === 'text-node') {
-        
+
         const nodeId = object?.data?.id;
         if (!nodeId) {
           console.warn('No node id found', object);

--- a/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
+++ b/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
@@ -53,6 +53,29 @@ export class TextNodeOptionsController {
     if (colorsUnique.length === 1) {
         this.textNodeOptionsStore.setColor(colorsUnique[0] as string);
     }
+
+    //TODO: need to somehow get the isComment state here.
+    //      then set the textnode-options.store to either true or false on selection
+    const isComments = textNodes.map((textNode) => {
+        const nodeId = textNode?.data?.id;
+
+        if (!nodeId) {
+          console.log('No node id found');
+          return null;
+        }
+
+        const node = this.textNodeStore.get(nodeId);
+
+        if (!node) {
+          console.log('No node found in store');
+          return null;
+        }
+        this.textNodeOptionsStore.setIsComment(node.isComment);
+        return node.isComment;
+    })
+    
+    console.log('ON SELECTION isComment: ', isComments);
+
   }
 
   /**

--- a/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
+++ b/packages/mapo-webapp/src/app/services/textnode-options/textnode-options.controller.ts
@@ -9,6 +9,7 @@ import { SelectionService } from "../selection/selection.service";
   providedIn: 'root',
 })
 export class TextNodeOptionsController {
+
   canvas: fabric.Canvas | null = null;
 
   constructor(
@@ -89,6 +90,7 @@ export class TextNodeOptionsController {
     let updated = false;
     for (const object of objects) {
       if (object instanceof fabric.Group && object?.data?.type === 'text-node') {
+        
         const nodeId = object?.data?.id;
         if (!nodeId) {
           console.warn('No node id found', object);

--- a/packages/mapo-webapp/src/app/services/toolbar/toolbar.controller.ts
+++ b/packages/mapo-webapp/src/app/services/toolbar/toolbar.controller.ts
@@ -50,6 +50,11 @@ export class ToolbarController {
       return;
     }
 
+    if (e.key === 'c') {
+      this.toolbarService.selectOrCancel(Tool.CREATE_COMMENT_NODE);
+      return;
+    }
+
     if (e.key === 'e') {
       this.toolbarService.selectOrCancel(Tool.CREATE_EDGE);
       return;

--- a/packages/mapo-webapp/src/app/store/textnode-options.store.ts
+++ b/packages/mapo-webapp/src/app/store/textnode-options.store.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
+
 @Injectable({
   providedIn: 'root',
 })

--- a/packages/mapo-webapp/src/app/store/textnode-options.store.ts
+++ b/packages/mapo-webapp/src/app/store/textnode-options.store.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
-
 @Injectable({
   providedIn: 'root',
 })
 export class TextNodeOptionsStore {
   color = new BehaviorSubject<string>('#FFFFFF');
   color$ = this.color.asObservable();
+
+  isComment = new BehaviorSubject<boolean>(false);
+  isComment$ = this.isComment.asObservable();
 
   setColor(color: string) {
     if (color) {
@@ -17,5 +19,13 @@ export class TextNodeOptionsStore {
 
   getColor(): string {
     return this.color.value;
+  }
+
+  setIsComment(isComment: boolean) {
+    this.isComment.next(isComment);
+  }
+
+  getIsComment(): boolean {
+    return this.isComment.value;
   }
 }

--- a/packages/mapo-webapp/src/app/store/textnode-options.store.ts
+++ b/packages/mapo-webapp/src/app/store/textnode-options.store.ts
@@ -9,9 +9,6 @@ export class TextNodeOptionsStore {
   color = new BehaviorSubject<string>('#FFFFFF');
   color$ = this.color.asObservable();
 
-  isComment = new BehaviorSubject<boolean>(false);
-  isComment$ = this.isComment.asObservable();
-
   setColor(color: string) {
     if (color) {
       this.color.next(color);
@@ -20,13 +17,5 @@ export class TextNodeOptionsStore {
 
   getColor(): string {
     return this.color.value;
-  }
-
-  setIsComment(isComment: boolean) {
-    this.isComment.next(isComment);
-  }
-
-  getIsComment(): boolean {
-    return this.isComment.value;
   }
 }

--- a/packages/mapo-webapp/src/app/store/toolbar.store.ts
+++ b/packages/mapo-webapp/src/app/store/toolbar.store.ts
@@ -5,6 +5,7 @@ export enum Tool {
   POINTER = 'pointer',
   PAN = 'pan',
   CREATE_TEXT_NODE = 'create-text-node',
+  CREATE_COMMENT_NODE = 'create-comment-node', //create a new comment tool
   CREATE_EDGE = 'create-edge',
   EDIT_TEXT_NODE = 'edit-text-node', // Not a real tool, but a valid state the user can be in
 }

--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -165,7 +165,7 @@ export class FabricUtils {
       left: rectLeft,
       width,
       height,
-      fill: textnode.color ?? '#FFFFFF',
+      fill: textnode.isComment ? 'transparent' : textnode.color ?? '#FFFFFF',
       rx: 10,
       ry: 10,
       stroke: textnode.isComment ? '#FFFFFF' : 'black',

--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -158,15 +158,28 @@ export class FabricUtils {
     const width = boundingRect.width + padding * 2;
     const height = boundingRect.height + padding * 2;
 
+    let fill = '#FFFFFF';
+    if (textnode.color) {
+      fill = textnode.color;
+    }
+    if (textnode.isComment) {
+      fill = '';
+    }
+
+    let stroke = 'black';
+    if (textnode.isComment) {
+      stroke = '';
+    }
+
     const rect = new fabric.Rect({
       top: rectTop,
       left: rectLeft,
       width,
       height,
-      fill: textnode.color ?? '#FFFFFF',
+      fill: fill,
       rx: 10,
       ry: 10,
-      stroke: textnode.isComment ? '#FFFFFF' : 'black',
+      stroke: stroke,
       strokeWidth: 1,
       hasControls: false,
     });
@@ -177,6 +190,7 @@ export class FabricUtils {
       data: {
         id: textnode.id,
         type: 'text-node',
+        isComment: textnode.isComment,
       },
     });
 

--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -150,8 +150,6 @@ export class FabricUtils {
       fontFamily: 'Roboto',
     });
 
-    console.log("CREATE TEXT NODE:", textnode.isComment); // todo: delete later
-
     const boundingRect = textObj.getBoundingRect(true);
 
     const padding = 10;

--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -163,7 +163,7 @@ export class FabricUtils {
       left: rectLeft,
       width,
       height,
-      fill: textnode.isComment ? 'transparent' : textnode.color ?? '#FFFFFF',
+      fill: textnode.color ?? '#FFFFFF',
       rx: 10,
       ry: 10,
       stroke: textnode.isComment ? '#FFFFFF' : 'black',

--- a/packages/mapo-webapp/src/app/utils/fabric-utils.ts
+++ b/packages/mapo-webapp/src/app/utils/fabric-utils.ts
@@ -150,6 +150,8 @@ export class FabricUtils {
       fontFamily: 'Roboto',
     });
 
+    console.log("CREATE TEXT NODE:", textnode.isComment); // todo: delete later
+
     const boundingRect = textObj.getBoundingRect(true);
 
     const padding = 10;
@@ -166,7 +168,7 @@ export class FabricUtils {
       fill: textnode.color ?? '#FFFFFF',
       rx: 10,
       ry: 10,
-      stroke: 'black',
+      stroke: textnode.isComment ? '#FFFFFF' : 'black',
       strokeWidth: 1,
       hasControls: false,
     });

--- a/tests/manual-tests.md
+++ b/tests/manual-tests.md
@@ -32,6 +32,14 @@ My Files:
     T: I see the button "Go to My Files"
 ```
 
+## Comments
+```
+Create comment:
+    W: I click on the comment tool and then click on the canvas
+    T: I can create a comment
+    T: The comment has no background or border
+```
+
 ## Text Nodes
 ```
 (Automated) Enter edit mode:
@@ -170,6 +178,16 @@ Panning (trackpad):
 
 Zoom (trackpad):
     G: I am using a trackpad
+    W: I pinch with 2 fingers
+    T: The canvas should zoom
+
+Panning (phone):
+    G: I am using a phone
+    W: I drag with 1 finger
+    T: The canvas should pan
+
+Zoom (phone):
+    G: I am using a phone
     W: I pinch with 2 fingers
     T: The canvas should zoom
 
@@ -407,6 +425,11 @@ Update color of a node:
     G: I have a node selected 
     W: I click on a color
     T: That node is updated to my selected color
+
+Update color of a comment:
+    G: I am on the canvas
+    G: I have a comment selected
+    T: the color options don't show up
 
 Update color of many nodes:
     G: I am on the canvas


### PR DESCRIPTION
Overview -
Created a new button on the canvas to create comments. Comments are Nodes with a transparent border and are unable to have a background color. Therefore, I disabled the background color modal for comments. 


In depth Overview -
Changing the border ~
[toolbar.component.html]
	- create a new button on the page to make a comment. Almost exactly like text node button but with a new Tool and Icon. 
[textnode.model]
	- Added a new variable to the zod schema validation
	- (isComment : boolean ) default = false
[text-node.controller]
	- On mouse down event and double click event, declare isComment as either T or F depending on what tool was selected. 
	- Added isComment to addPendingTextNode()
[text-node.service]
	- addPendingTextNode(), add isComment, send isComment in itext.data
	- finalizedTextNode(), get isComment state from itext.data, send isComment state to textNodeStore(). 
[text-node.store]
	- no changes
[fabric.utils]
	- added a condition so that if isComment = true, then set border 'stroke' to transparent.

Remove background color modal ~
[textnode-options.controller]
	- on selection, get the state of isComment then send a setComment(true) to the textnode-options store
[textnode-options.store]
	- create an 'observerable' for isComment, similar to color so that textnode-options.component can subscribe to it. 
[textnode-options.component]
	- it was already subsribed to the textnode-options.store, so all we have to do is add isComment to the visible function and create a if statement returning false if isComment = true. 


<img width="1673" alt="Mapo-CommentsFeature" src="https://github.com/user-attachments/assets/a0490784-27d8-4d86-b413-ec98604875bf" />
