### PR TITLE
Fix: #141 Bottom Toolbar open when editing a text node

### DIFF
--- a/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.html
+++ b/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.html
@@ -1,4 +1,4 @@
-<div class="bottom-toolbar-container" *ngIf="isVisible$ | async">
+<div class="bottom-toolbar-container" *ngIf="(isVisible$ | async) && !isEditing">
   <div
     *ngIf="colorEnabled$ | async"
     class="button color-button"

--- a/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.ts
+++ b/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 import { CanvasService } from '../../services/canvas/canvas.service';
 import { ClipboardService } from '../../services/clipboard/clipboard.service';
 import { BottomToolbarStore } from '../../store/bottom-toolbar.store';
 import { EdgeStore } from '../../store/edge.store';
 import { SelectionStore } from '../../store/selection.store';
 import { TextNodeStore } from '../../store/text-node.store';
+import { TextNodeService } from '../../services/text-node/text-node.service';
 @Component({
   selector: 'bottom-toolbar',
   standalone: true,
@@ -16,6 +17,7 @@ import { TextNodeStore } from '../../store/text-node.store';
 })
 export class BottomToolbarComponent {
   canvas: fabric.Canvas | null = null;
+  isEditing: boolean = false;
 
   isVisible$ = this.selectionStore.selection$.pipe(
     map((selection) => {
@@ -35,12 +37,12 @@ export class BottomToolbarComponent {
     })
   )
 
-
   constructor(
     private canvasService: CanvasService,
     private selectionStore: SelectionStore,
     private bottomToolbarStore: BottomToolbarStore,
     private clipboardService: ClipboardService,
+    private textNodeService: TextNodeService,
     private textNodeStore: TextNodeStore,
     private edgeStore: EdgeStore,
   ) {
@@ -50,8 +52,10 @@ export class BottomToolbarComponent {
     this.canvasService.canvasDestroyed$.subscribe((canvas) => {
       this.canvas = null;
     });
+    this.textNodeService.isEditing$.subscribe((editing) => {
+      this.isEditing = editing;
+    })
   }
-
 
   onClickColor() {
     const currentValue = this.bottomToolbarStore.getShowPallet();
@@ -59,7 +63,6 @@ export class BottomToolbarComponent {
   }
 
   onClickDelete() {
-
     this.canvas?.getActiveObjects().forEach((object) => {
       if (object.data?.type === 'text-node') {
         this.textNodeStore.remove(object.data.id);


### PR DESCRIPTION
Issue #141 :
When trying to edit an existing text node, the bottom toolbar would show. Also neither of the buttons would work while the user was in the pendingTextNode state. 

Thoughts/Solution:
First, I thought that using the 'edit-text-node' tool would work, but when you select a text node, that changes the tool to 'edit-text-node'. Meaning It would be difficult to use this tool to check if the bottom toolbar should be shown or not. I ended up using an observable to check if a user was editing a text node, then disabled the bottom toolbar when that was true.
 
Visual of the issue-
<img src="https://github.com/user-attachments/assets/84f977f8-beca-49dc-bc4e-dd484a6d6d20" width="200" />
