### PR TITLE
Fix: #132 Top toolbar padding issue 

### DIFF
--- a/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.less
+++ b/packages/mapo-webapp/src/app/components/toolbar/toolbar.component.less
@@ -1,9 +1,9 @@
 .toolbar-container {
-  margin: auto;
-  justify-content: center;
-
   display: flex;
+  justify-content: center;
   flex-direction: row;
+  margin: auto;
+  padding-bottom: 5px;
 
   .tool {
     height: 3rem;


### PR DESCRIPTION
Issue:
#132 

Solution:
Added 5px of padding bottom to the top toolbar. Now the letters are not cut off when hovering over a text node. 

Solution Screen Shot:
<img width="300" alt="Mapo-132-fix" src="https://github.com/user-attachments/assets/8fdf6d54-2abf-4a9f-8bf6-88bea70770e9" />
