### PR TITLE
Feature/Fixes: Arrows

### DIFF
--- a/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.html
+++ b/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.html
@@ -13,6 +13,7 @@
     <i class="ri-delete-bin-line"></i>
   </div>
   <div
+    *ngIf="copyEnabled$ | async"
     class="button copy-button"
     (click)="onClickCopy()"
   >

--- a/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.ts
+++ b/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.ts
@@ -8,6 +8,7 @@ import { EdgeStore } from '../../store/edge.store';
 import { SelectionStore } from '../../store/selection.store';
 import { TextNodeStore } from '../../store/text-node.store';
 import { TextNodeService } from '../../services/text-node/text-node.service';
+import { EdgeService } from '../../services/edge/edge.service';
 @Component({
   selector: 'bottom-toolbar',
   standalone: true,
@@ -43,6 +44,7 @@ export class BottomToolbarComponent {
     private bottomToolbarStore: BottomToolbarStore,
     private clipboardService: ClipboardService,
     private textNodeService: TextNodeService,
+    private edgeService: EdgeService,
     private textNodeStore: TextNodeStore,
     private edgeStore: EdgeStore,
   ) {
@@ -53,6 +55,9 @@ export class BottomToolbarComponent {
       this.canvas = null;
     });
     this.textNodeService.isEditing$.subscribe((editing) => {
+      this.isEditing = editing;
+    })
+    this.edgeService.isEditing$.subscribe((editing) => {
       this.isEditing = editing;
     })
   }

--- a/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.ts
+++ b/packages/mapo-webapp/src/app/components/bottom-toolbar/bottom-toolbar.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { combineLatest, map } from 'rxjs';
+import { map } from 'rxjs';
 import { CanvasService } from '../../services/canvas/canvas.service';
 import { ClipboardService } from '../../services/clipboard/clipboard.service';
 import { BottomToolbarStore } from '../../store/bottom-toolbar.store';
@@ -35,8 +35,20 @@ export class BottomToolbarComponent {
         );
       });
       return hasTextNode;
-    })
-  )
+    }),
+  );
+
+  copyEnabled$ = this.selectionStore.selection$.pipe(
+    map((selection) => {
+      // Return true only if there is at least 1 text node or comment in the selection
+      const hasTextNode = selection?.some((object) => {
+        return (
+          object.data?.type === 'text-node' && (object.data?.type !== 'edge' || object.data?.type !=='edge-text')
+        );
+      });
+      return hasTextNode;
+    }),
+  );
 
   constructor(
     private canvasService: CanvasService,
@@ -56,10 +68,10 @@ export class BottomToolbarComponent {
     });
     this.textNodeService.isEditing$.subscribe((editing) => {
       this.isEditing = editing;
-    })
+    });
     this.edgeService.isEditing$.subscribe((editing) => {
       this.isEditing = editing;
-    })
+    });
   }
 
   onClickColor() {

--- a/packages/mapo-webapp/src/app/controllers/hammertime.controller.ts
+++ b/packages/mapo-webapp/src/app/controllers/hammertime.controller.ts
@@ -6,6 +6,7 @@ import { HammertimePinchService } from "../services/hammertime/hammertime-pinch.
 import { HammertimePressService } from "../services/hammertime/hammertime-press.service";
 import { TextNodeService } from "../services/text-node/text-node.service";
 import { isTouchScreen } from "../utils/browser-utils";
+import { EdgeService } from "../services/edge/edge.service";
 
 @Injectable({
     providedIn: 'root'
@@ -20,6 +21,7 @@ export class HammertimeController {
         private hammertimePinchService: HammertimePinchService,
         private hammertimePressService: HammertimePressService,
         private textnodeService: TextNodeService,
+        private edgeService: EdgeService,
     ) {
         this.canvasService.canvasInitialized$.subscribe((canvas) => {
             this.canvas = canvas;
@@ -89,12 +91,16 @@ export class HammertimeController {
             true,
         );
 
+        // Double-tap on a text node
         if (target && target.data?.type === 'text-node') {
             this.textnodeService.editTextNode(target as fabric.Group);
         }
 
-
-        // TODO: Edit arrow text by double-tapping
+        // Double-tap on an edge, or edge-text
+        if (target && (target.data?.type === 'edge' || target.data?.type === 'edge-text')) {
+            const edgeId = target.data.id;
+            this.edgeService.editText(edgeId);
+        }
     }
 
     onPress = (e: HammerInput) => {

--- a/packages/mapo-webapp/src/app/controllers/mouse.controller.ts
+++ b/packages/mapo-webapp/src/app/controllers/mouse.controller.ts
@@ -126,7 +126,7 @@ export class MouseController {
         }
 
         if (isTouchScreen() && !e.target) {
-            // When using a touchscreen, clientX and clientY are not availabel for some reason.
+            // When using a touchscreen, clientX and clientY are not available for some reason.
             // but layerX and layerY are.
             this.panCanvasService.startPan(e.e.layerX, e.e.layerY); 
         }
@@ -160,7 +160,7 @@ export class MouseController {
         // If the user was in create-edge, and clicked on an actual node, start or finish an edge
         if (tool === Tool.CREATE_EDGE && e.target) {
 
-            // Double check that the object clicked on was actally a text-node
+            // Double check that the object clicked on was actually a text-node
             if (e.target?.data?.type !== 'text-node') {
                 this.drawEdgeService.removePendingEdge();
                 this.toolbarStore.setTool(Tool.POINTER);

--- a/packages/mapo-webapp/src/app/services/edge/edge.service.ts
+++ b/packages/mapo-webapp/src/app/services/edge/edge.service.ts
@@ -6,8 +6,8 @@ import { Tool, ToolbarStore } from '../../store/toolbar.store';
 import { FabricUtils } from '../../utils/fabric-utils';
 import { CanvasService } from '../canvas/canvas.service';
 import { combineLatest, sampleTime } from 'rxjs';
-import { TextNodeService } from '../text-node/text-node.service';
 import { TextNodeStore } from '../../store/text-node.store';
+import { BehaviorSubject } from 'rxjs';
 
 /**
  * Service used for rendering edges on the canvas
@@ -17,13 +17,13 @@ import { TextNodeStore } from '../../store/text-node.store';
 })
 export class EdgeService {
   canvas: fabric.Canvas | null = null;
-
+  isEditing = new BehaviorSubject<boolean>(false);
+  isEditing$ = this.isEditing.asObservable();
   constructor(
     private edgeStore: EdgeStore,
     private toolbarStore: ToolbarStore,
     private canvasService: CanvasService,
     private textNodeStore: TextNodeStore,
-    private textNodeService: TextNodeService,
   ) {
     this.canvasService.canvasInitialized$.subscribe((canvas) => {
       this.canvas = canvas;
@@ -141,6 +141,8 @@ export class EdgeService {
     FabricUtils.selectIText(this.canvas, itext);
     this.toolbarStore.setTool(Tool.EDIT_TEXT_NODE);
 
+    this.isEditing.next(true);
+
     itext.on('editing:exited', (e) => {
       if (!this.canvas) {
         console.warn('Canvas not initialized');
@@ -152,6 +154,7 @@ export class EdgeService {
       });
       this.canvas.remove(itext);
       this.toolbarStore.setTool(Tool.POINTER);
+      this.isEditing.next(false);
     });
   }
 }


### PR DESCRIPTION
1. Removed the copy button from the bottom toolbar when you select an arrow. 
2. Added the ability to double tap on an arrow to create the text over the arrow on mobile devices. 
3. Removed the bottom toolbar when you are editing the text over an arrow.